### PR TITLE
core: Added Generic CallFactoryReturns (upgrade to Go1.18)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0-rc1
+          go-version: 1.18
       - uses: actions/checkout@v2
       - name: go fmt
         run: |
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.0-rc1
+          go-version: 1.18
       - uses: actions/checkout@v2
       - name: go test
         run: go test ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18.0-rc1
       - uses: actions/checkout@v2
       - name: go fmt
         run: |
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18.0-rc1
       - uses: actions/checkout@v2
       - name: go test
         run: go test ./...

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -32,3 +32,8 @@ type Caller interface {
 	RequestCreator
 	ResponseHandler
 }
+
+// CallReturnsFactory is the interface that wraps the basic Returns method.
+type CallReturnsFactory[T any] interface {
+	Returns(T) Caller
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -35,10 +35,10 @@ type Caller interface {
 
 // CallFactoryReturns is the interface that wraps the basic Returns method.
 type CallFactoryReturns[T any] interface {
-	Returns(T) Caller
+	Returns(*T) Caller
 }
 
 // CallFactoryReturnsRAW is the interface that wraps the basic ReturnsRAW method.
 type CallFactoryReturnsRAW[T any] interface {
-	ReturnsRAW(T) Caller
+	ReturnsRAW(*T) Caller
 }

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -37,3 +37,8 @@ type Caller interface {
 type CallReturnsFactory[T any] interface {
 	Returns(T) Caller
 }
+
+// CallReturnsRAWFactory is the interface that wraps the basic ReturnsRAW method.
+type CallReturnsRAWFactory[T any] interface {
+	ReturnsRAW(T) Caller
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -33,12 +33,12 @@ type Caller interface {
 	ResponseHandler
 }
 
-// CallReturnsFactory is the interface that wraps the basic Returns method.
-type CallReturnsFactory[T any] interface {
+// CallFactoryReturns is the interface that wraps the basic Returns method.
+type CallFactoryReturns[T any] interface {
 	Returns(T) Caller
 }
 
-// CallReturnsRAWFactory is the interface that wraps the basic ReturnsRAW method.
-type CallReturnsRAWFactory[T any] interface {
+// CallFactoryReturnsRAW is the interface that wraps the basic ReturnsRAW method.
+type CallFactoryReturnsRAW[T any] interface {
 	ReturnsRAW(T) Caller
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lmittmann/w3
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ethereum/go-ethereum v1.10.16

--- a/module/eth/block_number.go
+++ b/module/eth/block_number.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BlockNumber requests the number of the most recent block.
-func BlockNumber() core.CallReturnsFactory[*big.Int] {
+func BlockNumber() core.CallFactoryReturns[*big.Int] {
 	return &blockNumberFactory{}
 }
 

--- a/module/eth/block_number.go
+++ b/module/eth/block_number.go
@@ -5,26 +5,27 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // BlockNumber requests the number of the most recent block.
-func BlockNumber() *BlockNumberFactory {
-	return &BlockNumberFactory{}
+func BlockNumber() core.CallReturnsFactory[*big.Int] {
+	return &blockNumberFactory{}
 }
 
-type BlockNumberFactory struct {
+type blockNumberFactory struct {
 	// returns
 	result  hexutil.Big
 	returns *big.Int
 }
 
-func (f *BlockNumberFactory) Returns(blockNumber *big.Int) *BlockNumberFactory {
+func (f *blockNumberFactory) Returns(blockNumber *big.Int) core.Caller {
 	f.returns = blockNumber
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *BlockNumberFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *blockNumberFactory) CreateRequest() (rpc.BatchElem, error) {
 	return rpc.BatchElem{
 		Method: "eth_blockNumber",
 		Result: &f.result,
@@ -32,7 +33,7 @@ func (f *BlockNumberFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *BlockNumberFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *blockNumberFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/block_number.go
+++ b/module/eth/block_number.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BlockNumber requests the number of the most recent block.
-func BlockNumber() core.CallFactoryReturns[*big.Int] {
+func BlockNumber() core.CallFactoryReturns[big.Int] {
 	return &blockNumberFactory{}
 }
 

--- a/module/eth/call.go
+++ b/module/eth/call.go
@@ -30,7 +30,7 @@ func (f *CallFactory) AtBlock(blockNumber *big.Int) *CallFactory {
 	return f
 }
 
-func (f *CallFactory) Returns(output *[]byte) *CallFactory {
+func (f *CallFactory) Returns(output *[]byte) core.Caller {
 	f.returns = output
 	return f
 }
@@ -76,7 +76,7 @@ func (f *CallFuncFactory) AtBlock(blockNumber *big.Int) *CallFuncFactory {
 	return f
 }
 
-func (f *CallFuncFactory) Returns(returns ...interface{}) *CallFuncFactory {
+func (f *CallFuncFactory) Returns(returns ...interface{}) core.Caller {
 	f.returns = returns
 	return f
 }

--- a/module/eth/chain_id.go
+++ b/module/eth/chain_id.go
@@ -3,26 +3,27 @@ package eth
 import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // ChainID requests the chains ID.
-func ChainID() *ChainIDFactory {
-	return &ChainIDFactory{}
+func ChainID() core.CallReturnsFactory[*uint64] {
+	return &chainIDFactory{}
 }
 
-type ChainIDFactory struct {
+type chainIDFactory struct {
 	// returns
 	result  hexutil.Uint64
 	returns *uint64
 }
 
-func (f *ChainIDFactory) Returns(chainID *uint64) *ChainIDFactory {
+func (f *chainIDFactory) Returns(chainID *uint64) core.Caller {
 	f.returns = chainID
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *ChainIDFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *chainIDFactory) CreateRequest() (rpc.BatchElem, error) {
 	return rpc.BatchElem{
 		Method: "eth_chainId",
 		Result: &f.result,
@@ -30,7 +31,7 @@ func (f *ChainIDFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *ChainIDFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *chainIDFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/chain_id.go
+++ b/module/eth/chain_id.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ChainID requests the chains ID.
-func ChainID() core.CallReturnsFactory[*uint64] {
+func ChainID() core.CallFactoryReturns[*uint64] {
 	return &chainIDFactory{}
 }
 

--- a/module/eth/chain_id.go
+++ b/module/eth/chain_id.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ChainID requests the chains ID.
-func ChainID() core.CallFactoryReturns[*uint64] {
+func ChainID() core.CallFactoryReturns[uint64] {
 	return &chainIDFactory{}
 }
 

--- a/module/eth/gas_price.go
+++ b/module/eth/gas_price.go
@@ -5,26 +5,27 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // GasPrice requests the current gas price in wei.
-func GasPrice() *GasPriceFactory {
-	return &GasPriceFactory{}
+func GasPrice() core.CallReturnsFactory[*big.Int] {
+	return &gasPriceFactory{}
 }
 
-type GasPriceFactory struct {
+type gasPriceFactory struct {
 	// returns
 	result  hexutil.Big
 	returns *big.Int
 }
 
-func (f *GasPriceFactory) Returns(gasPrice *big.Int) *GasPriceFactory {
+func (f *gasPriceFactory) Returns(gasPrice *big.Int) core.Caller {
 	f.returns = gasPrice
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *GasPriceFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *gasPriceFactory) CreateRequest() (rpc.BatchElem, error) {
 	return rpc.BatchElem{
 		Method: "eth_gasPrice",
 		Result: &f.result,
@@ -32,7 +33,7 @@ func (f *GasPriceFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *GasPriceFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *gasPriceFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/gas_price.go
+++ b/module/eth/gas_price.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GasPrice requests the current gas price in wei.
-func GasPrice() core.CallReturnsFactory[*big.Int] {
+func GasPrice() core.CallFactoryReturns[*big.Int] {
 	return &gasPriceFactory{}
 }
 

--- a/module/eth/gas_price.go
+++ b/module/eth/gas_price.go
@@ -9,7 +9,7 @@ import (
 )
 
 // GasPrice requests the current gas price in wei.
-func GasPrice() core.CallFactoryReturns[*big.Int] {
+func GasPrice() core.CallFactoryReturns[big.Int] {
 	return &gasPriceFactory{}
 }
 

--- a/module/eth/get_balance.go
+++ b/module/eth/get_balance.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // Balance requests the balance of the given common.Address addr.
@@ -28,7 +29,7 @@ func (f *BalanceFactory) AtBlock(blockNumber *big.Int) *BalanceFactory {
 	return f
 }
 
-func (f *BalanceFactory) Returns(balance *big.Int) *BalanceFactory {
+func (f *BalanceFactory) Returns(balance *big.Int) core.Caller {
 	f.returns = balance
 	return f
 }

--- a/module/eth/get_block_by_hash.go
+++ b/module/eth/get_block_by_hash.go
@@ -11,8 +11,8 @@ import (
 
 // BlockByHash requests the block with full transactions with the given hash.
 func BlockByHash(hash common.Hash) interface {
-	core.CallReturnsFactory[*types.Block]
-	core.CallReturnsRAWFactory[*RPCBlock]
+	core.CallFactoryReturns[*types.Block]
+	core.CallFactoryReturnsRAW[*RPCBlock]
 } {
 	return &blockByHashFactory{hash: hash}
 }
@@ -83,8 +83,8 @@ func (f *blockByHashFactory) HandleResponse(elem rpc.BatchElem) error {
 
 // HeaderByHash requests the header with the given hash.
 func HeaderByHash(hash common.Hash) interface {
-	core.CallReturnsFactory[*types.Header]
-	core.CallReturnsRAWFactory[*RPCHeader]
+	core.CallFactoryReturns[*types.Header]
+	core.CallFactoryReturnsRAW[*RPCHeader]
 } {
 	return &headerByHashFactory{hash: hash}
 }

--- a/module/eth/get_block_by_hash.go
+++ b/module/eth/get_block_by_hash.go
@@ -6,14 +6,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // BlockByHash requests the block with full transactions with the given hash.
-func BlockByHash(hash common.Hash) *BlockByHashFactory {
-	return &BlockByHashFactory{hash: hash}
+func BlockByHash(hash common.Hash) interface {
+	core.CallReturnsFactory[*types.Block]
+	core.CallReturnsRAWFactory[*RPCBlock]
+} {
+	return &blockByHashFactory{hash: hash}
 }
 
-type BlockByHashFactory struct {
+type blockByHashFactory struct {
 	// args
 	hash common.Hash
 
@@ -24,18 +28,18 @@ type BlockByHashFactory struct {
 	returnsRAW *RPCBlock
 }
 
-func (f *BlockByHashFactory) Returns(block *types.Block) *BlockByHashFactory {
+func (f *blockByHashFactory) Returns(block *types.Block) core.Caller {
 	f.returns = block
 	return f
 }
 
-func (f *BlockByHashFactory) ReturnsRAW(block *RPCBlock) *BlockByHashFactory {
+func (f *blockByHashFactory) ReturnsRAW(block *RPCBlock) core.Caller {
 	f.returnsRAW = block
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *BlockByHashFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *blockByHashFactory) CreateRequest() (rpc.BatchElem, error) {
 	if f.returns != nil {
 		return rpc.BatchElem{
 			Method: "eth_getBlockByHash",
@@ -51,7 +55,7 @@ func (f *BlockByHashFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *BlockByHashFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *blockByHashFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}
@@ -78,11 +82,14 @@ func (f *BlockByHashFactory) HandleResponse(elem rpc.BatchElem) error {
 }
 
 // HeaderByHash requests the header with the given hash.
-func HeaderByHash(hash common.Hash) *HeaderByHashFactory {
-	return &HeaderByHashFactory{hash: hash}
+func HeaderByHash(hash common.Hash) interface {
+	core.CallReturnsFactory[*types.Header]
+	core.CallReturnsRAWFactory[*RPCHeader]
+} {
+	return &headerByHashFactory{hash: hash}
 }
 
-type HeaderByHashFactory struct {
+type headerByHashFactory struct {
 	// args
 	hash common.Hash
 
@@ -93,18 +100,18 @@ type HeaderByHashFactory struct {
 	returnsRAW *RPCHeader
 }
 
-func (f *HeaderByHashFactory) Returns(header *types.Header) *HeaderByHashFactory {
+func (f *headerByHashFactory) Returns(header *types.Header) core.Caller {
 	f.returns = header
 	return f
 }
 
-func (f *HeaderByHashFactory) ReturnsRAW(header *RPCHeader) *HeaderByHashFactory {
+func (f *headerByHashFactory) ReturnsRAW(header *RPCHeader) core.Caller {
 	f.returnsRAW = header
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *HeaderByHashFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *headerByHashFactory) CreateRequest() (rpc.BatchElem, error) {
 	if f.returns != nil {
 		return rpc.BatchElem{
 			Method: "eth_getBlockByHash",
@@ -120,7 +127,7 @@ func (f *HeaderByHashFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *HeaderByHashFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *headerByHashFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/get_block_by_hash.go
+++ b/module/eth/get_block_by_hash.go
@@ -11,8 +11,8 @@ import (
 
 // BlockByHash requests the block with full transactions with the given hash.
 func BlockByHash(hash common.Hash) interface {
-	core.CallFactoryReturns[*types.Block]
-	core.CallFactoryReturnsRAW[*RPCBlock]
+	core.CallFactoryReturns[types.Block]
+	core.CallFactoryReturnsRAW[RPCBlock]
 } {
 	return &blockByHashFactory{hash: hash}
 }
@@ -83,8 +83,8 @@ func (f *blockByHashFactory) HandleResponse(elem rpc.BatchElem) error {
 
 // HeaderByHash requests the header with the given hash.
 func HeaderByHash(hash common.Hash) interface {
-	core.CallFactoryReturns[*types.Header]
-	core.CallFactoryReturnsRAW[*RPCHeader]
+	core.CallFactoryReturns[types.Header]
+	core.CallFactoryReturnsRAW[RPCHeader]
 } {
 	return &headerByHashFactory{hash: hash}
 }

--- a/module/eth/get_block_by_number.go
+++ b/module/eth/get_block_by_number.go
@@ -6,15 +6,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // BlockByNumber requests the block with full transactions with the given
 // number.
-func BlockByNumber(number *big.Int) *BlockByNumberFactory {
-	return &BlockByNumberFactory{number: number}
+func BlockByNumber(number *big.Int) interface {
+	core.CallReturnsFactory[*types.Block]
+	core.CallReturnsRAWFactory[*RPCBlock]
+} {
+	return &blockByNumberFactory{number: number}
 }
 
-type BlockByNumberFactory struct {
+type blockByNumberFactory struct {
 	// args
 	number *big.Int
 
@@ -25,18 +29,18 @@ type BlockByNumberFactory struct {
 	returnsRAW *RPCBlock
 }
 
-func (f *BlockByNumberFactory) Returns(block *types.Block) *BlockByNumberFactory {
+func (f *blockByNumberFactory) Returns(block *types.Block) core.Caller {
 	f.returns = block
 	return f
 }
 
-func (f *BlockByNumberFactory) ReturnsRAW(block *RPCBlock) *BlockByNumberFactory {
+func (f *blockByNumberFactory) ReturnsRAW(block *RPCBlock) core.Caller {
 	f.returnsRAW = block
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *BlockByNumberFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *blockByNumberFactory) CreateRequest() (rpc.BatchElem, error) {
 	if f.returns != nil {
 		return rpc.BatchElem{
 			Method: "eth_getBlockByNumber",
@@ -52,7 +56,7 @@ func (f *BlockByNumberFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *BlockByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *blockByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}
@@ -80,11 +84,14 @@ func (f *BlockByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
 }
 
 // HeaderByNumber requests the header with the given number.
-func HeaderByNumber(number *big.Int) *HeaderByNumberFactory {
-	return &HeaderByNumberFactory{number: number}
+func HeaderByNumber(number *big.Int) interface {
+	core.CallReturnsFactory[*types.Header]
+	core.CallReturnsRAWFactory[*RPCHeader]
+} {
+	return &headerByNumberFactory{number: number}
 }
 
-type HeaderByNumberFactory struct {
+type headerByNumberFactory struct {
 	// args
 	number *big.Int
 
@@ -95,18 +102,18 @@ type HeaderByNumberFactory struct {
 	returnsRAW *RPCHeader
 }
 
-func (f *HeaderByNumberFactory) Returns(header *types.Header) *HeaderByNumberFactory {
+func (f *headerByNumberFactory) Returns(header *types.Header) core.Caller {
 	f.returns = header
 	return f
 }
 
-func (f *HeaderByNumberFactory) ReturnsRAW(header *RPCHeader) *HeaderByNumberFactory {
+func (f *headerByNumberFactory) ReturnsRAW(header *RPCHeader) core.Caller {
 	f.returnsRAW = header
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *HeaderByNumberFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *headerByNumberFactory) CreateRequest() (rpc.BatchElem, error) {
 	if f.returns != nil {
 		return rpc.BatchElem{
 			Method: "eth_getBlockByNumber",
@@ -122,7 +129,7 @@ func (f *HeaderByNumberFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *HeaderByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *headerByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/get_block_by_number.go
+++ b/module/eth/get_block_by_number.go
@@ -12,8 +12,8 @@ import (
 // BlockByNumber requests the block with full transactions with the given
 // number.
 func BlockByNumber(number *big.Int) interface {
-	core.CallFactoryReturns[*types.Block]
-	core.CallFactoryReturnsRAW[*RPCBlock]
+	core.CallFactoryReturns[types.Block]
+	core.CallFactoryReturnsRAW[RPCBlock]
 } {
 	return &blockByNumberFactory{number: number}
 }
@@ -85,8 +85,8 @@ func (f *blockByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
 
 // HeaderByNumber requests the header with the given number.
 func HeaderByNumber(number *big.Int) interface {
-	core.CallFactoryReturns[*types.Header]
-	core.CallFactoryReturnsRAW[*RPCHeader]
+	core.CallFactoryReturns[types.Header]
+	core.CallFactoryReturnsRAW[RPCHeader]
 } {
 	return &headerByNumberFactory{number: number}
 }

--- a/module/eth/get_block_by_number.go
+++ b/module/eth/get_block_by_number.go
@@ -12,8 +12,8 @@ import (
 // BlockByNumber requests the block with full transactions with the given
 // number.
 func BlockByNumber(number *big.Int) interface {
-	core.CallReturnsFactory[*types.Block]
-	core.CallReturnsRAWFactory[*RPCBlock]
+	core.CallFactoryReturns[*types.Block]
+	core.CallFactoryReturnsRAW[*RPCBlock]
 } {
 	return &blockByNumberFactory{number: number}
 }
@@ -85,8 +85,8 @@ func (f *blockByNumberFactory) HandleResponse(elem rpc.BatchElem) error {
 
 // HeaderByNumber requests the header with the given number.
 func HeaderByNumber(number *big.Int) interface {
-	core.CallReturnsFactory[*types.Header]
-	core.CallReturnsRAWFactory[*RPCHeader]
+	core.CallFactoryReturns[*types.Header]
+	core.CallFactoryReturnsRAW[*RPCHeader]
 } {
 	return &headerByNumberFactory{number: number}
 }

--- a/module/eth/get_code.go
+++ b/module/eth/get_code.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // Code requests the contract code of the given common.Address addr.
@@ -28,7 +29,7 @@ func (f *CodeFactory) AtBlock(blockNumber *big.Int) *CodeFactory {
 	return f
 }
 
-func (f *CodeFactory) Returns(code *[]byte) *CodeFactory {
+func (f *CodeFactory) Returns(code *[]byte) core.Caller {
 	f.returns = code
 	return f
 }

--- a/module/eth/get_logs.go
+++ b/module/eth/get_logs.go
@@ -4,14 +4,15 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // Logs requests the logs of the given ethereum.FilterQuery q.
-func Logs(q ethereum.FilterQuery) *LogsFactory {
-	return &LogsFactory{filterQuery: q}
+func Logs(q ethereum.FilterQuery) core.CallReturnsFactory[*[]types.Log] {
+	return &logsFactory{filterQuery: q}
 }
 
-type LogsFactory struct {
+type logsFactory struct {
 	// args
 	filterQuery ethereum.FilterQuery
 
@@ -20,13 +21,13 @@ type LogsFactory struct {
 	returns *[]types.Log
 }
 
-func (f *LogsFactory) Returns(logs *[]types.Log) *LogsFactory {
+func (f *logsFactory) Returns(logs *[]types.Log) core.Caller {
 	f.returns = logs
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *LogsFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *logsFactory) CreateRequest() (rpc.BatchElem, error) {
 	arg, err := toFilterArg(f.filterQuery)
 	if err != nil {
 		return rpc.BatchElem{}, err
@@ -40,7 +41,7 @@ func (f *LogsFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *LogsFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *logsFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/get_logs.go
+++ b/module/eth/get_logs.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Logs requests the logs of the given ethereum.FilterQuery q.
-func Logs(q ethereum.FilterQuery) core.CallFactoryReturns[*[]types.Log] {
+func Logs(q ethereum.FilterQuery) core.CallFactoryReturns[[]types.Log] {
 	return &logsFactory{filterQuery: q}
 }
 

--- a/module/eth/get_logs.go
+++ b/module/eth/get_logs.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Logs requests the logs of the given ethereum.FilterQuery q.
-func Logs(q ethereum.FilterQuery) core.CallReturnsFactory[*[]types.Log] {
+func Logs(q ethereum.FilterQuery) core.CallFactoryReturns[*[]types.Log] {
 	return &logsFactory{filterQuery: q}
 }
 

--- a/module/eth/get_storage_at.go
+++ b/module/eth/get_storage_at.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // StorageAt requests the storage of the given common.Address addr at the
@@ -29,7 +30,7 @@ func (f *StorageAtFactory) AtBlock(blockNumber *big.Int) *StorageAtFactory {
 	return f
 }
 
-func (f *StorageAtFactory) Returns(storage *common.Hash) *StorageAtFactory {
+func (f *StorageAtFactory) Returns(storage *common.Hash) core.Caller {
 	f.returns = storage
 	return f
 }

--- a/module/eth/get_transaction_by_hash.go
+++ b/module/eth/get_transaction_by_hash.go
@@ -4,14 +4,18 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // TransactionByHash requests the transaction with the given hash.
-func TransactionByHash(hash common.Hash) *TransactionByHashFactory {
-	return &TransactionByHashFactory{hash: hash}
+func TransactionByHash(hash common.Hash) interface {
+	core.CallReturnsFactory[*types.Transaction]
+	core.CallReturnsRAWFactory[*RPCTransaction]
+} {
+	return &transactionByHashFactory{hash: hash}
 }
 
-type TransactionByHashFactory struct {
+type transactionByHashFactory struct {
 	// args
 	hash common.Hash
 
@@ -22,18 +26,18 @@ type TransactionByHashFactory struct {
 	returnsRAW *RPCTransaction
 }
 
-func (f *TransactionByHashFactory) Returns(tx *types.Transaction) *TransactionByHashFactory {
+func (f *transactionByHashFactory) Returns(tx *types.Transaction) core.Caller {
 	f.returns = tx
 	return f
 }
 
-func (f *TransactionByHashFactory) ReturnsRAW(tx *RPCTransaction) *TransactionByHashFactory {
+func (f *transactionByHashFactory) ReturnsRAW(tx *RPCTransaction) core.Caller {
 	f.returnsRAW = tx
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *TransactionByHashFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *transactionByHashFactory) CreateRequest() (rpc.BatchElem, error) {
 	if f.returns != nil {
 		return rpc.BatchElem{
 			Method: "eth_getTransactionByHash",
@@ -49,7 +53,7 @@ func (f *TransactionByHashFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *TransactionByHashFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *transactionByHashFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}

--- a/module/eth/get_transaction_by_hash.go
+++ b/module/eth/get_transaction_by_hash.go
@@ -9,8 +9,8 @@ import (
 
 // TransactionByHash requests the transaction with the given hash.
 func TransactionByHash(hash common.Hash) interface {
-	core.CallFactoryReturns[*types.Transaction]
-	core.CallFactoryReturnsRAW[*RPCTransaction]
+	core.CallFactoryReturns[types.Transaction]
+	core.CallFactoryReturnsRAW[RPCTransaction]
 } {
 	return &transactionByHashFactory{hash: hash}
 }

--- a/module/eth/get_transaction_by_hash.go
+++ b/module/eth/get_transaction_by_hash.go
@@ -9,8 +9,8 @@ import (
 
 // TransactionByHash requests the transaction with the given hash.
 func TransactionByHash(hash common.Hash) interface {
-	core.CallReturnsFactory[*types.Transaction]
-	core.CallReturnsRAWFactory[*RPCTransaction]
+	core.CallFactoryReturns[*types.Transaction]
+	core.CallFactoryReturnsRAW[*RPCTransaction]
 } {
 	return &transactionByHashFactory{hash: hash}
 }

--- a/module/eth/get_transaction_count.go
+++ b/module/eth/get_transaction_count.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // Nonce requests the nonce of the given common.Address addr.
@@ -28,7 +29,7 @@ func (f *NonceFactory) AtBlock(blockNumber *big.Int) *NonceFactory {
 	return f
 }
 
-func (f *NonceFactory) Returns(nonce *uint64) *NonceFactory {
+func (f *NonceFactory) Returns(nonce *uint64) core.Caller {
 	f.returns = nonce
 	return f
 }

--- a/module/eth/get_transaction_receipt.go
+++ b/module/eth/get_transaction_receipt.go
@@ -10,8 +10,8 @@ import (
 // TransactionReceipt requests the receipt of the transaction with the given
 // hash.
 func TransactionReceipt(hash common.Hash) interface {
-	core.CallReturnsFactory[*types.Receipt]
-	core.CallReturnsRAWFactory[*RPCReceipt]
+	core.CallFactoryReturns[*types.Receipt]
+	core.CallFactoryReturnsRAW[*RPCReceipt]
 } {
 	return &transactionReceiptFactory{hash: hash}
 }

--- a/module/eth/get_transaction_receipt.go
+++ b/module/eth/get_transaction_receipt.go
@@ -10,8 +10,8 @@ import (
 // TransactionReceipt requests the receipt of the transaction with the given
 // hash.
 func TransactionReceipt(hash common.Hash) interface {
-	core.CallFactoryReturns[*types.Receipt]
-	core.CallFactoryReturnsRAW[*RPCReceipt]
+	core.CallFactoryReturns[types.Receipt]
+	core.CallFactoryReturnsRAW[RPCReceipt]
 } {
 	return &transactionReceiptFactory{hash: hash}
 }

--- a/module/eth/send_raw_transaction.go
+++ b/module/eth/send_raw_transaction.go
@@ -9,12 +9,12 @@ import (
 )
 
 // SendTransaction sends a signed transaction to the network.
-func SendTransaction(tx *types.Transaction) core.CallFactoryReturns[*common.Hash] {
+func SendTransaction(tx *types.Transaction) core.CallFactoryReturns[common.Hash] {
 	return &sendRawTransactionFactory{tx: tx}
 }
 
 // SendRawTransaction sends a raw transaction to the network.
-func SendRawTransaction(rawTx []byte) core.CallFactoryReturns[*common.Hash] {
+func SendRawTransaction(rawTx []byte) core.CallFactoryReturns[common.Hash] {
 	return &sendRawTransactionFactory{rawTx: rawTx}
 }
 

--- a/module/eth/send_raw_transaction.go
+++ b/module/eth/send_raw_transaction.go
@@ -9,12 +9,12 @@ import (
 )
 
 // SendTransaction sends a signed transaction to the network.
-func SendTransaction(tx *types.Transaction) core.CallReturnsFactory[*common.Hash] {
+func SendTransaction(tx *types.Transaction) core.CallFactoryReturns[*common.Hash] {
 	return &sendRawTransactionFactory{tx: tx}
 }
 
 // SendRawTransaction sends a raw transaction to the network.
-func SendRawTransaction(rawTx []byte) core.CallReturnsFactory[*common.Hash] {
+func SendRawTransaction(rawTx []byte) core.CallFactoryReturns[*common.Hash] {
 	return &sendRawTransactionFactory{rawTx: rawTx}
 }
 

--- a/module/eth/send_raw_transaction.go
+++ b/module/eth/send_raw_transaction.go
@@ -5,19 +5,20 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3/core"
 )
 
 // SendTransaction sends a signed transaction to the network.
-func SendTransaction(tx *types.Transaction) *SendRawTransactionFactory {
-	return &SendRawTransactionFactory{tx: tx}
+func SendTransaction(tx *types.Transaction) core.CallReturnsFactory[*common.Hash] {
+	return &sendRawTransactionFactory{tx: tx}
 }
 
 // SendRawTransaction sends a raw transaction to the network.
-func SendRawTransaction(rawTx []byte) *SendRawTransactionFactory {
-	return &SendRawTransactionFactory{rawTx: rawTx}
+func SendRawTransaction(rawTx []byte) core.CallReturnsFactory[*common.Hash] {
+	return &sendRawTransactionFactory{rawTx: rawTx}
 }
 
-type SendRawTransactionFactory struct {
+type sendRawTransactionFactory struct {
 	// args
 	tx    *types.Transaction
 	rawTx []byte
@@ -27,13 +28,13 @@ type SendRawTransactionFactory struct {
 	returns *common.Hash
 }
 
-func (f *SendRawTransactionFactory) Returns(hash *common.Hash) *SendRawTransactionFactory {
+func (f *sendRawTransactionFactory) Returns(hash *common.Hash) core.Caller {
 	f.returns = hash
 	return f
 }
 
 // CreateRequest implements the core.RequestCreator interface.
-func (f *SendRawTransactionFactory) CreateRequest() (rpc.BatchElem, error) {
+func (f *sendRawTransactionFactory) CreateRequest() (rpc.BatchElem, error) {
 	if f.tx != nil {
 		rawTx, err := f.tx.MarshalBinary()
 		if err != nil {
@@ -50,7 +51,7 @@ func (f *SendRawTransactionFactory) CreateRequest() (rpc.BatchElem, error) {
 }
 
 // HandleResponse implements the core.ResponseHandler interface.
-func (f *SendRawTransactionFactory) HandleResponse(elem rpc.BatchElem) error {
+func (f *sendRawTransactionFactory) HandleResponse(elem rpc.BatchElem) error {
 	if err := elem.Error; err != nil {
 		return err
 	}


### PR DESCRIPTION
The generic `core.CallFactoryReturns` interface hides the actual factory implementation. This reduces the number of exported types in `module/eth` an improves documentation readability. 