### PR TITLE
Allow getting blocks with only transaction hashes, and not full transactions

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -278,7 +278,7 @@ func BenchmarkCall_Block100(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			requests := make([]w3types.Caller, len(block100))
 			for j := 0; j < len(requests); j++ {
-				requests[j] = eth.BlockByNumber(block100[j]).Returns(&block)
+				requests[j] = eth.BlockByNumber(block100[j], true).Returns(&block)
 			}
 			w3Client.Call(requests...)
 		}

--- a/module/eth/block.go
+++ b/module/eth/block.go
@@ -11,20 +11,22 @@ import (
 )
 
 // BlockByHash requests the block with the given hash with full transactions.
-func BlockByHash(hash common.Hash) w3types.CallerFactory[types.Block] {
+// If hydrate is false, only the transaction hashes will be requested, and not the full transactions.
+func BlockByHash(hash common.Hash, hydrate bool) w3types.CallerFactory[types.Block] {
 	return module.NewFactory(
 		"eth_getBlockByHash",
-		[]any{hash, true},
+		[]any{hash, hydrate},
 		module.WithRetWrapper(blockRetWrapper),
 	)
 }
 
 // BlockByNumber requests the block with the given number with full
 // transactions. If number is nil, the latest block is requested.
-func BlockByNumber(number *big.Int) w3types.CallerFactory[types.Block] {
+// If hydrate is false, only the transaction hashes will be requested, and not the full transactions.
+func BlockByNumber(number *big.Int, hydrate bool) w3types.CallerFactory[types.Block] {
 	return module.NewFactory(
 		"eth_getBlockByNumber",
-		[]any{module.BlockNumberArg(number), true},
+		[]any{module.BlockNumberArg(number), hydrate},
 		module.WithRetWrapper(blockRetWrapper),
 	)
 }

--- a/module/eth/block_test.go
+++ b/module/eth/block_test.go
@@ -19,7 +19,7 @@ func TestBlockByHash(t *testing.T) {
 	tests := []rpctest.TestCase[types.Block]{
 		{
 			Golden: "get_block_by_hash__1",
-			Call:   eth.BlockByHash(w3.H("0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6")),
+			Call:   eth.BlockByHash(w3.H("0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6"), true),
 			WantRet: *types.NewBlockWithHeader(&types.Header{
 				ParentHash:  w3.H("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
 				UncleHash:   w3.H("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
@@ -40,7 +40,7 @@ func TestBlockByHash(t *testing.T) {
 		},
 		{
 			Golden: "get_block_by_hash__46147",
-			Call:   eth.BlockByHash(w3.H("0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd")),
+			Call:   eth.BlockByHash(w3.H("0x4e3a3754410177e6937ef1f84bba68ea139e8d1a2258c5f85db9f1cd715a1bdd"), true),
 			WantRet: *types.NewBlockWithHeader(&types.Header{
 				ParentHash:  w3.H("0x5a41d0e66b4120775176c09fcf39e7c0520517a13d2b57b18d33d342df038bfc"),
 				UncleHash:   w3.H("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
@@ -74,7 +74,7 @@ func TestBlockByHash(t *testing.T) {
 		},
 		{
 			Golden:  "get_block_by_hash__0x00",
-			Call:    eth.BlockByHash(common.Hash{}),
+			Call:    eth.BlockByHash(common.Hash{}, true),
 			WantErr: errors.New("w3: call failed: not found"),
 		},
 	}
@@ -89,7 +89,7 @@ func TestBlockByNumber(t *testing.T) {
 	tests := []rpctest.TestCase[types.Block]{
 		{
 			Golden: "get_block_by_number__1",
-			Call:   eth.BlockByNumber(big.NewInt(1)),
+			Call:   eth.BlockByNumber(big.NewInt(1), true),
 			WantRet: *types.NewBlockWithHeader(&types.Header{
 				ParentHash:  w3.H("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"),
 				UncleHash:   w3.H("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
@@ -110,7 +110,7 @@ func TestBlockByNumber(t *testing.T) {
 		},
 		{
 			Golden: "get_block_by_number__46147",
-			Call:   eth.BlockByNumber(big.NewInt(46147)),
+			Call:   eth.BlockByNumber(big.NewInt(46147), true),
 			WantRet: *types.NewBlockWithHeader(&types.Header{
 				ParentHash:  w3.H("0x5a41d0e66b4120775176c09fcf39e7c0520517a13d2b57b18d33d342df038bfc"),
 				UncleHash:   w3.H("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"),
@@ -144,7 +144,7 @@ func TestBlockByNumber(t *testing.T) {
 		},
 		{
 			Golden:  "get_block_by_number__999999999",
-			Call:    eth.BlockByNumber(big.NewInt(999999999)),
+			Call:    eth.BlockByNumber(big.NewInt(999999999), true),
 			WantErr: errors.New("w3: call failed: not found"),
 		},
 	}


### PR DESCRIPTION
Aims to fix the removal of the RPCHeader type that just had a list of transaction hashes