### PR TITLE
Fix panic on property name missmatch

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -213,7 +213,7 @@ func TestFuncDecodeArgs(t *testing.T) {
 			Func:    MustNewFunc("test((address arg0, uint256 arg1))", ""),
 			Input:   B("0xffffffff000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000002a"),
 			Args:    []any{new(tupleWithUnexportedProperty)},
-			WantErr: errors.New("abi: invalid type: field \"Arg0\" does not exist on dest struct"),
+			WantErr: errors.New(`abi: invalid type: field "Arg0" does not exist on dest struct`),
 		},
 	}
 

--- a/func_test.go
+++ b/func_test.go
@@ -209,6 +209,12 @@ func TestFuncDecodeArgs(t *testing.T) {
 			Args:    []any{new(common.Address), new(big.Int)},
 			WantErr: errors.New("w3: insufficient input length"),
 		},
+		{
+			Func:    MustNewFunc("test((address arg0, uint256 arg1))", ""),
+			Input:   B("0xffffffff000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000002a"),
+			Args:    []any{new(tupleWithUnexportedProperty)},
+			WantErr: errors.New("abi: invalid type: field \"Arg0\" does not exist"),
+		},
 	}
 
 	for i, test := range tests {
@@ -301,6 +307,11 @@ func hashPtr(h common.Hash) *common.Hash { return &h }
 
 type tuple struct {
 	Arg0 common.Address
+	Arg1 *big.Int
+}
+
+type tupleWithUnexportedProperty struct {
+	arg0 common.Address
 	Arg1 *big.Int
 }
 

--- a/func_test.go
+++ b/func_test.go
@@ -213,7 +213,7 @@ func TestFuncDecodeArgs(t *testing.T) {
 			Func:    MustNewFunc("test((address arg0, uint256 arg1))", ""),
 			Input:   B("0xffffffff000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000002a"),
 			Args:    []any{new(tupleWithUnexportedProperty)},
-			WantErr: errors.New("abi: invalid type: field \"Arg0\" does not exist"),
+			WantErr: errors.New("abi: invalid type: field \"Arg0\" does not exist on dest struct"),
 		},
 	}
 

--- a/internal/abi/arguments.go
+++ b/internal/abi/arguments.go
@@ -183,7 +183,7 @@ func copyTuple(rDst, rSrc reflect.Value) error {
 	for i := 0; i < rSrc.NumField(); i++ {
 		fieldName := rSrc.Type().Field(i).Name
 		if rDst.Elem().FieldByName(fieldName).Kind() == reflect.Invalid {
-			return fmt.Errorf("%w: field %q does not exist", errInvalidType, fieldName)
+			return fmt.Errorf("%w: field %q does not exist on dest struct", errInvalidType, fieldName)
 		}
 		rDst.Elem().FieldByName(fieldName).Set(rSrc.Field(i))
 	}

--- a/internal/abi/arguments.go
+++ b/internal/abi/arguments.go
@@ -182,6 +182,9 @@ func copyTuple(rDst, rSrc reflect.Value) error {
 
 	for i := 0; i < rSrc.NumField(); i++ {
 		fieldName := rSrc.Type().Field(i).Name
+		if rDst.Elem().FieldByName(fieldName).Kind() == reflect.Invalid {
+			return fmt.Errorf("%w: field %q does not exist", errInvalidType, fieldName)
+		}
 		rDst.Elem().FieldByName(fieldName).Set(rSrc.Field(i))
 	}
 	return nil


### PR DESCRIPTION
Currently, if you try to decode into a dest struct that doesn't have the same properties as the src struct, the code panics with:
```
panic: reflect: call of reflect.Value.Set on zero Value [recovered]
        panic: reflect: call of reflect.Value.Set on zero Value
```
this happens in:
https://github.com/lmittmann/w3/blob/c0c1b2972348d77d7fb65392ae69518d4ccb645f/internal/abi/arguments.go#L185

## Example
```golang
// imagine we're calling decode on a func with the following signature:
// "test((address arg0, uint256 arg1))"

// we have the following dest struct:
type tupleWithUnexportedProperty struct {
	arg0 common.Address // note this unexported property!
	Arg1 *big.Int
}

// -------------------------------------------------------

// once we get to the snippet causing the issue, the values will be as follows:
fieldName // == "Arg0"
rDst.Elem().FieldByName("Arg0").Kind() // == reflect.Invalid, because "Arg0" does not exist on tupleWithUnexportedProperty struct

// thus this then panics
rDst.Elem().FieldByName(fieldName).Set(rSrc.Field(i))
```