### PR TITLE
Changed `eth.CallFunc(f, contract, args...)` to `eth.CallFunc(contract, f, args...)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ var (
 )
 
 err := client.Call(
-	eth.CallFunc(funcBalanceOf, weth9, addr).Returns(&weth9Balance),
-	eth.CallFunc(funcBalanceOf, dai, addr).Returns(&daiBalance),
+	eth.CallFunc(weth9, funcBalanceOf, addr).Returns(&weth9Balance),
+	eth.CallFunc(dai, funcBalanceOf, addr).Returns(&daiBalance),
 )
 ```
 
@@ -157,7 +157,7 @@ err := client.Call(
 ## Custom RPC Methods
 
 Custom RPC methods can be called with the `w3` client by creating a
-[`core.Caller`](https://pkg.go.dev/github.com/lmittmann/w3/core#Caller)
+[`w3types.Caller`](https://pkg.go.dev/github.com/lmittmann/w3/w3types#Caller)
 implementation.
 The `w3/module/eth` package can be used as implementation reference.
 
@@ -190,7 +190,7 @@ List of supported RPC methods.
 | Method                                    | Go Code
 | :---------------------------------------- | :-------
 | `eth_blockNumber`                         | `eth.BlockNumber().Returns(blockNumber *big.Int)`
-| `eth_call`                                | `eth.Call(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State).Returns(output *[]byte)`<br>`eth.CallFunc(fn core.Func, contract common.Address, args ...any).Returns(returns ...any)`
+| `eth_call`                                | `eth.Call(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State).Returns(output *[]byte)`<br>`eth.CallFunc(contract common.Address, f w3types.Func, args ...any).Returns(returns ...any)`
 | `eth_chainId`                             | `eth.ChainID().Returns(chainID *uint64)`
 | `eth_createAccessList`                    | `eth.AccessList(msg *w3types.Message, blockNumber *big.Int).Returns(resp *eth.AccessListResponse)`
 | `eth_estimateGas`                         | `eth.EstimateGas(msg *w3types.Message, blockNumber *big.Int).Returns(gas *uint64)`

--- a/client_test.go
+++ b/client_test.go
@@ -70,7 +70,7 @@ func ExampleClient_Call() {
 	// HTTP request).
 	if err := client.Call(
 		eth.Balance(addr, nil).Returns(&ethBalance),
-		eth.CallFunc(balanceOf, weth9, addr).Returns(&weth9Balance),
+		eth.CallFunc(weth9, balanceOf, addr).Returns(&weth9Balance),
 	); err != nil {
 		fmt.Printf("Request failed: %v\n", err)
 		return
@@ -307,7 +307,7 @@ func BenchmarkCall_BalanceOf100(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			requests := make([]w3types.Caller, len(addr100))
 			for j := 0; j < len(requests); j++ {
-				requests[j] = eth.CallFunc(funcBalanceOf, addrWeth9, addr100[j]).Returns(&balance)
+				requests[j] = eth.CallFunc(addrWeth9, funcBalanceOf, addr100[j]).Returns(&balance)
 			}
 			w3Client.Call(requests...)
 		}

--- a/examples/token_balance/main.go
+++ b/examples/token_balance/main.go
@@ -59,10 +59,10 @@ func main() {
 		balance      big.Int
 	)
 	if err := client.Call(
-		eth.CallFunc(funcName, addrToken).Returns(&name),
-		eth.CallFunc(funcSymbol, addrToken).Returns(&symbol),
-		eth.CallFunc(funcDecimals, addrToken).Returns(&decimals),
-		eth.CallFunc(funcBalanceOf, addrToken, addrAcc).Returns(&balance),
+		eth.CallFunc(addrToken, funcName).Returns(&name),
+		eth.CallFunc(addrToken, funcSymbol).Returns(&symbol),
+		eth.CallFunc(addrToken, funcDecimals).Returns(&decimals),
+		eth.CallFunc(addrToken, funcBalanceOf, addrAcc).Returns(&balance),
 	); err != nil {
 		fmt.Printf("Call failed: %v\n", err)
 		return

--- a/examples/uniswap_quote/main.go
+++ b/examples/uniswap_quote/main.go
@@ -69,12 +69,12 @@ func main() {
 		tokenOutDecimals uint8
 	)
 	if err := client.Call(
-		eth.CallFunc(funcName, addrTokenIn).Returns(&tokenInName),
-		eth.CallFunc(funcSymbol, addrTokenIn).Returns(&tokenInSymbol),
-		eth.CallFunc(funcDecimals, addrTokenIn).Returns(&tokenInDecimals),
-		eth.CallFunc(funcName, addrTokenOut).Returns(&tokenOutName),
-		eth.CallFunc(funcSymbol, addrTokenOut).Returns(&tokenOutSymbol),
-		eth.CallFunc(funcDecimals, addrTokenOut).Returns(&tokenOutDecimals),
+		eth.CallFunc(addrTokenIn, funcName).Returns(&tokenInName),
+		eth.CallFunc(addrTokenIn, funcSymbol).Returns(&tokenInSymbol),
+		eth.CallFunc(addrTokenIn, funcDecimals).Returns(&tokenInDecimals),
+		eth.CallFunc(addrTokenOut, funcName).Returns(&tokenOutName),
+		eth.CallFunc(addrTokenOut, funcSymbol).Returns(&tokenOutSymbol),
+		eth.CallFunc(addrTokenOut, funcDecimals).Returns(&tokenOutDecimals),
 	); err != nil {
 		fmt.Printf("Failed to fetch token details: %v\n", err)
 		return
@@ -87,7 +87,7 @@ func main() {
 		amountsOut = make([]big.Int, len(fees))
 	)
 	for i, fee := range fees {
-		calls[i] = eth.CallFunc(funcQuoteExactInputSingle, addrUniV3Quoter, addrTokenIn, addrTokenOut, fee, &amountIn, w3.Big0).Returns(&amountsOut[i])
+		calls[i] = eth.CallFunc(addrUniV3Quoter, funcQuoteExactInputSingle, addrTokenIn, addrTokenOut, fee, &amountIn, w3.Big0).Returns(&amountsOut[i])
 	}
 	err := client.Call(calls...)
 	callErrs, ok := err.(w3.CallErrors)

--- a/module/eth/call.go
+++ b/module/eth/call.go
@@ -89,16 +89,16 @@ func msgArgsWrapper(slice []any) ([]any, error) {
 	return slice, nil
 }
 
-// CallFunc requests the returns of Func fn at common.Address contract with the
+// CallFunc requests the returns of Func f at common.Address contract with the
 // given args.
-func CallFunc(fn w3types.Func, contract common.Address, args ...any) *CallFuncFactory {
-	return &CallFuncFactory{fn: fn, contract: contract, args: args}
+func CallFunc(contract common.Address, f w3types.Func, args ...any) *CallFuncFactory {
+	return &CallFuncFactory{contract: contract, f: f, args: args}
 }
 
 type CallFuncFactory struct {
 	// args
-	fn        w3types.Func
 	contract  common.Address
+	f         w3types.Func
 	args      []any
 	atBlock   *big.Int
 	overrides w3types.State
@@ -124,7 +124,7 @@ func (f *CallFuncFactory) Overrides(overrides w3types.State) *CallFuncFactory {
 }
 
 func (f *CallFuncFactory) CreateRequest() (rpc.BatchElem, error) {
-	input, err := f.fn.EncodeArgs(f.args...)
+	input, err := f.f.EncodeArgs(f.args...)
 	if err != nil {
 		return rpc.BatchElem{}, err
 	}
@@ -152,7 +152,7 @@ func (f *CallFuncFactory) HandleResponse(elem rpc.BatchElem) error {
 		return err
 	}
 
-	if err := f.fn.DecodeReturns(f.result, f.returns...); err != nil {
+	if err := f.f.DecodeReturns(f.result, f.returns...); err != nil {
 		return err
 	}
 	return nil

--- a/module/eth/call_test.go
+++ b/module/eth/call_test.go
@@ -61,7 +61,7 @@ func TestCallFunc(t *testing.T) {
 		wantBalance = big.NewInt(0)
 	)
 	if err := client.Call(
-		eth.CallFunc(funcBalanceOf, w3.A("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), w3.A("0x000000000000000000000000000000000000c0Fe")).Returns(balance),
+		eth.CallFunc(w3.A("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), funcBalanceOf, w3.A("0x000000000000000000000000000000000000c0Fe")).Returns(balance),
 	); err != nil {
 		t.Fatalf("Request failed: %v", err)
 	}


### PR DESCRIPTION
This is a breaking change that swaps `eth.CallFunc`'s first two parameters `f` and `contract`.

```diff
- eth.CallFunc(f, contract, args...)
+ eth.CallFunc(contract, f, args...)
```