### PR TITLE
Add support for tuples with unnamed fields.

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -280,6 +280,36 @@ func TestFuncDecodeArgs(t *testing.T) {
 			}},
 		},
 		{
+			// https://github.com/lmittmann/w3/issues/67
+			Func:     w3.MustNewFunc("test((address, uint256))", ""),
+			Input:    w3.B("0xba71720c000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000002a"),
+			Args:     []any{nil},
+			WantArgs: []any{nil},
+		},
+		{
+			// https://github.com/lmittmann/w3/issues/67
+			Func:  w3.MustNewFunc("test((address, uint256))", ""),
+			Input: w3.B("0xba71720c000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000002a"),
+			Args:  []any{new(tuple)},
+			WantArgs: []any{&tuple{
+				Arg0: w3.A("0x000000000000000000000000000000000000c0Fe"),
+				Arg1: big.NewInt(42),
+			}},
+		},
+		{
+			// https://github.com/lmittmann/w3/issues/67
+			Func:  w3.MustNewFunc("test((address, (address, uint256)))", ""),
+			Input: w3.B("0x1a68b84c000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000dead000000000000000000000000000000000000000000000000000000000000002a"),
+			Args:  []any{new(tupleNested)},
+			WantArgs: []any{&tupleNested{
+				Arg0: w3.A("0x000000000000000000000000000000000000c0Fe"),
+				Arg1: tuple{
+					Arg0: w3.A("0x000000000000000000000000000000000000dEaD"),
+					Arg1: big.NewInt(42),
+				},
+			}},
+		},
+		{
 			Func:  w3.MustNewFunc("test((address arg0, uint256 arg1))", ""),
 			Input: w3.B("0xba71720c000000000000000000000000000000000000000000000000000000000000c0fe000000000000000000000000000000000000000000000000000000000000002a"),
 			Args:  []any{new(tupleWithWrongOrder)},
@@ -494,4 +524,9 @@ type tupleIssue35 struct {
 	Recipients []struct {
 		To common.Address
 	}
+}
+
+type tupleNested struct {
+	Arg0 common.Address
+	Arg1 tuple
 }

--- a/internal/abi/parser.go
+++ b/internal/abi/parser.go
@@ -193,7 +193,7 @@ func (p *parser) parseType() (*abi.Type, error) {
 	return typ, nil
 }
 
-func (p *parser) parseTupleType() (*abi.Type, string, error) {
+func (p *parser) parseTupleType(i int) (*abi.Type, string, error) {
 	typ, err := p.parseType()
 	if err != nil {
 		return nil, "", err
@@ -202,7 +202,9 @@ func (p *parser) parseTupleType() (*abi.Type, string, error) {
 	// parse name
 	next := p.next()
 	if next.Typ != itemTypeID {
-		return nil, "", fmt.Errorf(`unexpected %s, want name`, next)
+		// no name given; put the token back and make up a fake name
+		p.backup()
+		return typ, fmt.Sprintf("arg%d", i), nil
 	}
 
 	return typ, next.Val, nil
@@ -215,9 +217,9 @@ func (p *parser) parseTupleTypes() (*abi.Type, error) {
 
 	typ := &abi.Type{T: abi.TupleTy}
 	fields := make([]reflect.StructField, 0)
-	for {
+	for i := 0; ; i++ {
 		// parse type
-		elemTyp, name, err := p.parseTupleType()
+		elemTyp, name, err := p.parseTupleType(i)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This should fix https://github.com/lmittmann/w3/issues/67 in a reasonable way. It generates placeholder names `arg0`, `arg1`, etc., for unnamed tuples. You can decode into a corresponding struct where the fields are named `Arg0`, `Arg1`, etc. Nested tuples are also suppoted.