### PR TITLE
Added GasTipCap method

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ List of supported RPC methods.
 | `eth_createAccessList`                    | `eth.AccessList(msg *w3types.Message, blockNumber *big.Int).Returns(resp *eth.AccessListResponse)`
 | `eth_estimateGas`                         | `eth.EstimateGas(msg *w3types.Message, blockNumber *big.Int).Returns(gas *uint64)`
 | `eth_gasPrice`                            | `eth.GasPrice().Returns(gasPrice *big.Int)`
+| `eth_maxPriorityFeePerGas`                | `eth.GasTipCap().Returns(gasTipCap *big.Int)`
 | `eth_getBalance`                          | `eth.Balance(addr common.Address, blockNumber *big.Int).Returns(balance *big.Int)`
 | `eth_getBlockByHash`                      | `eth.BlockByHash(hash common.Hash).Returns(block *types.Block)`<br>`eth.HeaderByHash(hash common.Hash).Returns(header *types.Header)`
 | `eth_getBlockByNumber`                    | `eth.BlockByNumber(number *big.Int).Returns(block *types.Block)`<br>`eth.HeaderByNumber(number *big.Int).Returns(header *types.Header)`

--- a/module/eth/gas_tip_cap.go
+++ b/module/eth/gas_tip_cap.go
@@ -1,0 +1,17 @@
+package eth
+
+import (
+	"math/big"
+
+	"github.com/lmittmann/w3/internal/module"
+	"github.com/lmittmann/w3/w3types"
+)
+
+// GasTipCap requests the current gas tip cap after 1559 in wei.
+func GasTipCap() w3types.CallerFactory[big.Int] {
+	return module.NewFactory(
+		"eth_maxPriorityFeePerGas",
+		nil,
+		module.WithRetWrapper(module.HexBigRetWrapper),
+	)
+}

--- a/module/eth/gas_tip_cap.go
+++ b/module/eth/gas_tip_cap.go
@@ -7,7 +7,8 @@ import (
 	"github.com/lmittmann/w3/w3types"
 )
 
-// GasTipCap requests the current gas tip cap after 1559 in wei.
+// GasTipCap requests the currently suggested gas tip cap after EIP-1559 to
+// allow a timely execution of a transaction.
 func GasTipCap() w3types.CallerFactory[big.Int] {
 	return module.NewFactory(
 		"eth_maxPriorityFeePerGas",

--- a/module/eth/gas_tip_cap_test.go
+++ b/module/eth/gas_tip_cap_test.go
@@ -1,0 +1,22 @@
+package eth_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/lmittmann/w3"
+	"github.com/lmittmann/w3/module/eth"
+	"github.com/lmittmann/w3/rpctest"
+)
+
+func TesGasTipCap(t *testing.T) {
+	tests := []rpctest.TestCase[big.Int]{
+		{
+			Golden:  "eth_maxPriorityFeePerGas",
+			Call:    eth.GasTipCap(),
+			WantRet: *w3.I("0xc0fe"),
+		},
+	}
+
+	rpctest.RunTestCases(t, tests)
+}

--- a/module/eth/gas_tip_cap_test.go
+++ b/module/eth/gas_tip_cap_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/lmittmann/w3/rpctest"
 )
 
-func TesGasTipCap(t *testing.T) {
+func TestGasTipCap(t *testing.T) {
 	tests := []rpctest.TestCase[big.Int]{
 		{
-			Golden:  "eth_maxPriorityFeePerGas",
+			Golden:  "gas_tip_cap",
 			Call:    eth.GasTipCap(),
 			WantRet: *w3.I("0xc0fe"),
 		},

--- a/module/eth/testdata/gas_tip_cap.golden
+++ b/module/eth/testdata/gas_tip_cap.golden
@@ -1,0 +1,2 @@
+> {"jsonrpc":"2.0","id":1,"method":"eth_maxPriorityFeePerGas"}
+< {"jsonrpc":"2.0","id":1,"result":"0xc0fe"}


### PR DESCRIPTION
Hello, @lmittmann,

I'm not entirely sure if this method is necessary because it's not mentioned in the specification: https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods

However, we do have the same method in `ethclient`: https://github.com/ethereum/go-ethereum/blob/v1.13.5/ethclient/ethclient.go#L564

This method facilitates the sending of transactions without relying on additional libraries or etherscan.