### PR TITLE
w3types: Refactored `Caller`,  `CallerFactory` -> `RPCCaller`, `RPCCallerFactory`

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func (c *Client) Close() error {
 //
 // An error is returned if RPC request creation, networking, or RPC response
 // handling fails.
-func (c *Client) CallCtx(ctx context.Context, calls ...w3types.Caller) error {
+func (c *Client) CallCtx(ctx context.Context, calls ...w3types.RPCCaller) error {
 	// no requests = nothing to do
 	if len(calls) <= 0 {
 		return nil
@@ -133,7 +133,7 @@ func (c *Client) CallCtx(ctx context.Context, calls ...w3types.Caller) error {
 }
 
 // Call is like [Client.CallCtx] with ctx equal to context.Background().
-func (c *Client) Call(calls ...w3types.Caller) error {
+func (c *Client) Call(calls ...w3types.RPCCaller) error {
 	return c.CallCtx(context.Background(), calls...)
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -106,26 +106,26 @@ func ExampleClient_Call_nonceAndBalance() {
 func TestClientCall(t *testing.T) {
 	tests := []struct {
 		Buf     *bytes.Buffer
-		Calls   []w3types.Caller
+		Calls   []w3types.RPCCaller
 		WantErr error
 	}{
 		{
 			Buf:   bytes.NewBufferString(jsonCalls1),
-			Calls: []w3types.Caller{&testCaller{}},
+			Calls: []w3types.RPCCaller{&testCaller{}},
 		},
 		{
 			Buf:     bytes.NewBufferString(jsonCalls1),
-			Calls:   []w3types.Caller{&testCaller{RequestErr: errors.New("err")}},
+			Calls:   []w3types.RPCCaller{&testCaller{RequestErr: errors.New("err")}},
 			WantErr: errors.New("err"),
 		},
 		{
 			Buf:     bytes.NewBufferString(jsonCalls1),
-			Calls:   []w3types.Caller{&testCaller{ReturnErr: errors.New("err")}},
+			Calls:   []w3types.RPCCaller{&testCaller{ReturnErr: errors.New("err")}},
 			WantErr: errors.New("w3: call failed: err"),
 		},
 		{
 			Buf: bytes.NewBufferString(jsonCalls2),
-			Calls: []w3types.Caller{
+			Calls: []w3types.RPCCaller{
 				&testCaller{RequestErr: errors.New("err")},
 				&testCaller{},
 			},
@@ -133,7 +133,7 @@ func TestClientCall(t *testing.T) {
 		},
 		{
 			Buf: bytes.NewBufferString(jsonCalls2),
-			Calls: []w3types.Caller{
+			Calls: []w3types.RPCCaller{
 				&testCaller{ReturnErr: errors.New("err")},
 				&testCaller{},
 			},
@@ -141,7 +141,7 @@ func TestClientCall(t *testing.T) {
 		},
 		{
 			Buf: bytes.NewBufferString(jsonCalls2),
-			Calls: []w3types.Caller{
+			Calls: []w3types.RPCCaller{
 				&testCaller{},
 				&testCaller{ReturnErr: errors.New("err")},
 			},
@@ -149,7 +149,7 @@ func TestClientCall(t *testing.T) {
 		},
 		{
 			Buf: bytes.NewBufferString(jsonCalls2),
-			Calls: []w3types.Caller{
+			Calls: []w3types.RPCCaller{
 				&testCaller{ReturnErr: errors.New("err")},
 				&testCaller{ReturnErr: errors.New("err")},
 			},
@@ -266,7 +266,7 @@ func BenchmarkCall_Balance100(b *testing.B) {
 	b.Run("Batch", func(b *testing.B) {
 		var balance big.Int
 		for i := 0; i < b.N; i++ {
-			requests := make([]w3types.Caller, len(addr100))
+			requests := make([]w3types.RPCCaller, len(addr100))
 			for j := 0; j < len(requests); j++ {
 				requests[j] = eth.Balance(addr100[j], nil).Returns(&balance)
 			}
@@ -305,7 +305,7 @@ func BenchmarkCall_BalanceOf100(b *testing.B) {
 	b.Run("Batch", func(b *testing.B) {
 		var balance big.Int
 		for i := 0; i < b.N; i++ {
-			requests := make([]w3types.Caller, len(addr100))
+			requests := make([]w3types.RPCCaller, len(addr100))
 			for j := 0; j < len(requests); j++ {
 				requests[j] = eth.CallFunc(addrWeth9, funcBalanceOf, addr100[j]).Returns(&balance)
 			}
@@ -348,7 +348,7 @@ func BenchmarkCall_Block100(b *testing.B) {
 	b.Run("Batch", func(b *testing.B) {
 		var block types.Block
 		for i := 0; i < b.N; i++ {
-			requests := make([]w3types.Caller, len(block100))
+			requests := make([]w3types.RPCCaller, len(block100))
 			for j := 0; j < len(requests); j++ {
 				requests[j] = eth.BlockByNumber(block100[j]).Returns(&block)
 			}

--- a/examples/scan_blocks/main.go
+++ b/examples/scan_blocks/main.go
@@ -47,7 +47,7 @@ func main() {
 	defer client.Close()
 
 	// fetch blocks in bulk
-	calls := make([]w3types.Caller, bulkSize)
+	calls := make([]w3types.RPCCaller, bulkSize)
 	blocks := make([]types.Block, bulkSize)
 
 	for i, txCount := 0, 0; ; i++ {

--- a/examples/uniswap_quote/main.go
+++ b/examples/uniswap_quote/main.go
@@ -83,7 +83,7 @@ func main() {
 	// fetch quotes
 	var (
 		fees       = []*big.Int{big.NewInt(100), big.NewInt(500), big.NewInt(3000), big.NewInt(10000)}
-		calls      = make([]w3types.Caller, len(fees))
+		calls      = make([]w3types.RPCCaller, len(fees))
 		amountsOut = make([]big.Int, len(fees))
 	)
 	for i, fee := range fees {

--- a/internal/module/factory.go
+++ b/internal/module/factory.go
@@ -43,7 +43,7 @@ func NewFactory[T any](method string, args []any, opts ...Option[T]) *Factory[T]
 	return f
 }
 
-func (f Factory[T]) Returns(ret *T) w3types.Caller {
+func (f Factory[T]) Returns(ret *T) w3types.RPCCaller {
 	f.ret = ret
 	return f
 }

--- a/module/debug/call_trace.go
+++ b/module/debug/call_trace.go
@@ -11,7 +11,7 @@ import (
 )
 
 // CallTraceCall requests the call trace of the given message.
-func CallTraceCall(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State) w3types.CallerFactory[CallTrace] {
+func CallTraceCall(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State) w3types.RPCCallerFactory[CallTrace] {
 	return module.NewFactory(
 		"debug_traceCall",
 		[]any{msg, module.BlockNumberArg(blockNumber), &traceConfig{Tracer: "callTracer", Overrides: overrides}},
@@ -20,7 +20,7 @@ func CallTraceCall(msg *w3types.Message, blockNumber *big.Int, overrides w3types
 }
 
 // CallTraceTx requests the call trace of the transaction with the given hash.
-func CallTraceTx(txHash common.Hash, overrides w3types.State) w3types.CallerFactory[CallTrace] {
+func CallTraceTx(txHash common.Hash, overrides w3types.State) w3types.RPCCallerFactory[CallTrace] {
 	return module.NewFactory[CallTrace](
 		"debug_traceTransaction",
 		[]any{txHash, &traceConfig{Tracer: "callTracer", Overrides: overrides}},

--- a/module/debug/trace.go
+++ b/module/debug/trace.go
@@ -14,7 +14,7 @@ import (
 )
 
 // TraceCall requests the trace of the given message.
-func TraceCall(msg *w3types.Message, blockNumber *big.Int, config *TraceConfig) w3types.CallerFactory[Trace] {
+func TraceCall(msg *w3types.Message, blockNumber *big.Int, config *TraceConfig) w3types.RPCCallerFactory[Trace] {
 	if config == nil {
 		config = &TraceConfig{}
 	}
@@ -26,7 +26,7 @@ func TraceCall(msg *w3types.Message, blockNumber *big.Int, config *TraceConfig) 
 }
 
 // TraceTx requests the trace of the transaction with the given hash.
-func TraceTx(txHash common.Hash, config *TraceConfig) w3types.CallerFactory[Trace] {
+func TraceTx(txHash common.Hash, config *TraceConfig) w3types.RPCCallerFactory[Trace] {
 	if config == nil {
 		config = &TraceConfig{}
 	}

--- a/module/eth/balance.go
+++ b/module/eth/balance.go
@@ -11,7 +11,7 @@ import (
 // Balance requests the balance of the given common.Address addr at the given
 // blockNumber. If blockNumber is nil, the balance at the latest known block is
 // requested.
-func Balance(addr common.Address, blockNumber *big.Int) w3types.CallerFactory[big.Int] {
+func Balance(addr common.Address, blockNumber *big.Int) w3types.RPCCallerFactory[big.Int] {
 	return module.NewFactory(
 		"eth_getBalance",
 		[]any{addr, module.BlockNumberArg(blockNumber)},

--- a/module/eth/block.go
+++ b/module/eth/block.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BlockByHash requests the block with the given hash with full transactions.
-func BlockByHash(hash common.Hash) w3types.CallerFactory[types.Block] {
+func BlockByHash(hash common.Hash) w3types.RPCCallerFactory[types.Block] {
 	return module.NewFactory(
 		"eth_getBlockByHash",
 		[]any{hash, true},
@@ -21,7 +21,7 @@ func BlockByHash(hash common.Hash) w3types.CallerFactory[types.Block] {
 
 // BlockByNumber requests the block with the given number with full
 // transactions. If number is nil, the latest block is requested.
-func BlockByNumber(number *big.Int) w3types.CallerFactory[types.Block] {
+func BlockByNumber(number *big.Int) w3types.RPCCallerFactory[types.Block] {
 	return module.NewFactory(
 		"eth_getBlockByNumber",
 		[]any{module.BlockNumberArg(number), true},
@@ -31,7 +31,7 @@ func BlockByNumber(number *big.Int) w3types.CallerFactory[types.Block] {
 
 // BlockTxCountByHash requests the number of transactions in the block with the
 // given hash.
-func BlockTxCountByHash(hash common.Hash) w3types.CallerFactory[uint] {
+func BlockTxCountByHash(hash common.Hash) w3types.RPCCallerFactory[uint] {
 	return module.NewFactory(
 		"eth_getBlockTransactionCountByHash",
 		[]any{hash},
@@ -41,7 +41,7 @@ func BlockTxCountByHash(hash common.Hash) w3types.CallerFactory[uint] {
 
 // BlockTxCountByNumber requests the number of transactions in the block with
 // the given number.
-func BlockTxCountByNumber(number *big.Int) w3types.CallerFactory[uint] {
+func BlockTxCountByNumber(number *big.Int) w3types.RPCCallerFactory[uint] {
 	return module.NewFactory(
 		"eth_getBlockTransactionCountByNumber",
 		[]any{module.BlockNumberArg(number)},
@@ -50,7 +50,7 @@ func BlockTxCountByNumber(number *big.Int) w3types.CallerFactory[uint] {
 }
 
 // HeaderByHash requests the header with the given hash.
-func HeaderByHash(hash common.Hash) w3types.CallerFactory[types.Header] {
+func HeaderByHash(hash common.Hash) w3types.RPCCallerFactory[types.Header] {
 	return module.NewFactory[types.Header](
 		"eth_getBlockByHash",
 		[]any{hash, false},
@@ -59,7 +59,7 @@ func HeaderByHash(hash common.Hash) w3types.CallerFactory[types.Header] {
 
 // HeaderByNumber requests the header with the given number. If number is nil,
 // the latest header is requested.
-func HeaderByNumber(number *big.Int) w3types.CallerFactory[types.Header] {
+func HeaderByNumber(number *big.Int) w3types.RPCCallerFactory[types.Header] {
 	return module.NewFactory[types.Header](
 		"eth_getBlockByNumber",
 		[]any{module.BlockNumberArg(number), false},

--- a/module/eth/block_number.go
+++ b/module/eth/block_number.go
@@ -8,7 +8,7 @@ import (
 )
 
 // BlockNumber requests the number of the most recent block.
-func BlockNumber() w3types.CallerFactory[big.Int] {
+func BlockNumber() w3types.RPCCallerFactory[big.Int] {
 	return module.NewFactory(
 		"eth_blockNumber",
 		nil,

--- a/module/eth/call.go
+++ b/module/eth/call.go
@@ -15,7 +15,7 @@ import (
 // Call requests the output data of the given message at the given blockNumber.
 // If blockNumber is nil, the output of the message at the latest known block is
 // requested.
-func Call(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State) w3types.CallerFactory[[]byte] {
+func Call(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State) w3types.RPCCallerFactory[[]byte] {
 	args := []any{msg, module.BlockNumberArg(blockNumber)}
 	if overrides != nil {
 		args = append(args, overrides)
@@ -32,7 +32,7 @@ func Call(msg *w3types.Message, blockNumber *big.Int, overrides w3types.State) w
 // EstimateGas requests the estimated gas cost of the given message at the given
 // blockNumber. If blockNumber is nil, the estimated gas cost of the message at
 // the latest block is requested.
-func EstimateGas(msg *w3types.Message, blockNumber *big.Int) w3types.CallerFactory[uint64] {
+func EstimateGas(msg *w3types.Message, blockNumber *big.Int) w3types.RPCCallerFactory[uint64] {
 	return module.NewFactory(
 		"eth_estimateGas",
 		[]any{msg, module.BlockNumberArg(blockNumber)},
@@ -44,7 +44,7 @@ func EstimateGas(msg *w3types.Message, blockNumber *big.Int) w3types.CallerFacto
 // AccessList requests the access list of the given message at the given
 // blockNumber. If blockNumber is nil, the access list of the message at the
 // latest block is requested.
-func AccessList(msg *w3types.Message, blockNumber *big.Int) w3types.CallerFactory[AccessListResponse] {
+func AccessList(msg *w3types.Message, blockNumber *big.Int) w3types.RPCCallerFactory[AccessListResponse] {
 	return module.NewFactory(
 		"eth_createAccessList",
 		[]any{msg, module.BlockNumberArg(blockNumber)},
@@ -110,7 +110,7 @@ type CallFuncFactory struct {
 	returns []any
 }
 
-func (f *CallFuncFactory) Returns(returns ...any) w3types.Caller {
+func (f *CallFuncFactory) Returns(returns ...any) w3types.RPCCaller {
 	f.returns = returns
 	return f
 }

--- a/module/eth/chain_id.go
+++ b/module/eth/chain_id.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ChainID requests the chains ID.
-func ChainID() w3types.CallerFactory[uint64] {
+func ChainID() w3types.RPCCallerFactory[uint64] {
 	return module.NewFactory(
 		"eth_chainId",
 		nil,

--- a/module/eth/code.go
+++ b/module/eth/code.go
@@ -11,7 +11,7 @@ import (
 // Code requests the code of the given common.Address addr at the given
 // blockNumber. If blockNumber is nil, the code at the latest known block is
 // requested.
-func Code(addr common.Address, blockNumber *big.Int) w3types.CallerFactory[[]byte] {
+func Code(addr common.Address, blockNumber *big.Int) w3types.RPCCallerFactory[[]byte] {
 	return module.NewFactory(
 		"eth_getCode",
 		[]any{addr, module.BlockNumberArg(blockNumber)},

--- a/module/eth/gas_price.go
+++ b/module/eth/gas_price.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GasPrice requests the current gas price in wei.
-func GasPrice() w3types.CallerFactory[big.Int] {
+func GasPrice() w3types.RPCCallerFactory[big.Int] {
 	return module.NewFactory(
 		"eth_gasPrice",
 		nil,

--- a/module/eth/gas_tip_cap.go
+++ b/module/eth/gas_tip_cap.go
@@ -9,7 +9,7 @@ import (
 
 // GasTipCap requests the currently suggested gas tip cap after EIP-1559 to
 // allow a timely execution of a transaction.
-func GasTipCap() w3types.CallerFactory[big.Int] {
+func GasTipCap() w3types.RPCCallerFactory[big.Int] {
 	return module.NewFactory(
 		"eth_maxPriorityFeePerGas",
 		nil,

--- a/module/eth/get_logs.go
+++ b/module/eth/get_logs.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Logs requests the logs of the given ethereum.FilterQuery q.
-func Logs(q ethereum.FilterQuery) w3types.CallerFactory[[]types.Log] {
+func Logs(q ethereum.FilterQuery) w3types.RPCCallerFactory[[]types.Log] {
 	return &logsFactory{filterQuery: q}
 }
 
@@ -23,7 +23,7 @@ type logsFactory struct {
 	returns *[]types.Log
 }
 
-func (f *logsFactory) Returns(logs *[]types.Log) w3types.Caller {
+func (f *logsFactory) Returns(logs *[]types.Log) w3types.RPCCaller {
 	f.returns = logs
 	return f
 }

--- a/module/eth/storage_at.go
+++ b/module/eth/storage_at.go
@@ -11,7 +11,7 @@ import (
 // StorageAt requests the storage of the given common.Address addr at the
 // given common.Hash slot at the given blockNumber. If block number is nil, the
 // slot at the latest known block is requested.
-func StorageAt(addr common.Address, slot common.Hash, blockNumber *big.Int) w3types.CallerFactory[common.Hash] {
+func StorageAt(addr common.Address, slot common.Hash, blockNumber *big.Int) w3types.RPCCallerFactory[common.Hash] {
 	return module.NewFactory[common.Hash](
 		"eth_getStorageAt",
 		[]any{addr, slot, module.BlockNumberArg(blockNumber)},

--- a/module/eth/tx.go
+++ b/module/eth/tx.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Tx requests the transaction with the given hash.
-func Tx(hash common.Hash) w3types.CallerFactory[types.Transaction] {
+func Tx(hash common.Hash) w3types.RPCCallerFactory[types.Transaction] {
 	return module.NewFactory[types.Transaction](
 		"eth_getTransactionByHash",
 		[]any{hash},
@@ -19,7 +19,7 @@ func Tx(hash common.Hash) w3types.CallerFactory[types.Transaction] {
 }
 
 // TxByBlockHashAndIndex requests the transaction in the given block with the given index.
-func TxByBlockHashAndIndex(blockHash common.Hash, index uint64) w3types.CallerFactory[types.Transaction] {
+func TxByBlockHashAndIndex(blockHash common.Hash, index uint64) w3types.RPCCallerFactory[types.Transaction] {
 	return module.NewFactory[types.Transaction](
 		"eth_getTransactionByBlockHashAndIndex",
 		[]any{blockHash, hexutil.Uint64(index)},
@@ -27,7 +27,7 @@ func TxByBlockHashAndIndex(blockHash common.Hash, index uint64) w3types.CallerFa
 }
 
 // TxByBlockNumberAndIndex requests the transaction in the given block with the given index.
-func TxByBlockNumberAndIndex(blockNumber *big.Int, index uint64) w3types.CallerFactory[types.Transaction] {
+func TxByBlockNumberAndIndex(blockNumber *big.Int, index uint64) w3types.RPCCallerFactory[types.Transaction] {
 	return module.NewFactory[types.Transaction](
 		"eth_getTransactionByBlockNumberAndIndex",
 		[]any{module.BlockNumberArg(blockNumber), hexutil.Uint64(index)},
@@ -35,7 +35,7 @@ func TxByBlockNumberAndIndex(blockNumber *big.Int, index uint64) w3types.CallerF
 }
 
 // SendRawTx sends a raw transaction to the network and returns its hash.
-func SendRawTx(rawTx []byte) w3types.CallerFactory[common.Hash] {
+func SendRawTx(rawTx []byte) w3types.RPCCallerFactory[common.Hash] {
 	return module.NewFactory[common.Hash](
 		"eth_sendRawTransaction",
 		[]any{hexutil.Encode(rawTx)},
@@ -43,7 +43,7 @@ func SendRawTx(rawTx []byte) w3types.CallerFactory[common.Hash] {
 }
 
 // SendTx sends a signed transaction to the network and returns its hash.
-func SendTx(tx *types.Transaction) w3types.CallerFactory[common.Hash] {
+func SendTx(tx *types.Transaction) w3types.RPCCallerFactory[common.Hash] {
 	return module.NewFactory(
 		"eth_sendRawTransaction",
 		[]any{tx},
@@ -60,7 +60,7 @@ func SendTx(tx *types.Transaction) w3types.CallerFactory[common.Hash] {
 }
 
 // TxReceipt requests the receipt of the transaction with the given hash.
-func TxReceipt(txHash common.Hash) w3types.CallerFactory[types.Receipt] {
+func TxReceipt(txHash common.Hash) w3types.RPCCallerFactory[types.Receipt] {
 	return module.NewFactory[types.Receipt](
 		"eth_getTransactionReceipt",
 		[]any{txHash},
@@ -68,7 +68,7 @@ func TxReceipt(txHash common.Hash) w3types.CallerFactory[types.Receipt] {
 }
 
 // BlockReceipts requests all receipts of the transactions in the given block.
-func BlockReceipts(number *big.Int) w3types.CallerFactory[types.Receipts] {
+func BlockReceipts(number *big.Int) w3types.RPCCallerFactory[types.Receipts] {
 	return module.NewFactory[types.Receipts](
 		"eth_getBlockReceipts",
 		[]any{module.BlockNumberArg(number)},
@@ -78,7 +78,7 @@ func BlockReceipts(number *big.Int) w3types.CallerFactory[types.Receipts] {
 // Nonce requests the nonce of the given common.Address addr at the given
 // blockNumber. If blockNumber is nil, the nonce at the latest known block is
 // requested.
-func Nonce(addr common.Address, blockNumber *big.Int) w3types.CallerFactory[uint64] {
+func Nonce(addr common.Address, blockNumber *big.Int) w3types.RPCCallerFactory[uint64] {
 	return module.NewFactory(
 		"eth_getTransactionCount",
 		[]any{addr, module.BlockNumberArg(blockNumber)},

--- a/module/eth/uncle.go
+++ b/module/eth/uncle.go
@@ -12,7 +12,7 @@ import (
 
 // UncleByBlockHashAndIndex requests the uncle of the block with the given hash
 // at the given index.
-func UncleByBlockHashAndIndex(hash common.Hash, index uint) w3types.CallerFactory[types.Header] {
+func UncleByBlockHashAndIndex(hash common.Hash, index uint) w3types.RPCCallerFactory[types.Header] {
 	return module.NewFactory[types.Header](
 		"eth_getUncleByBlockHashAndIndex",
 		[]any{hash, hexutil.Uint(index)},
@@ -21,7 +21,7 @@ func UncleByBlockHashAndIndex(hash common.Hash, index uint) w3types.CallerFactor
 
 // UncleByBlockNumberAndIndex requests the uncle of the block with the given
 // number at the given index.
-func UncleByBlockNumberAndIndex(number *big.Int, index uint) w3types.CallerFactory[types.Header] {
+func UncleByBlockNumberAndIndex(number *big.Int, index uint) w3types.RPCCallerFactory[types.Header] {
 	return module.NewFactory[types.Header](
 		"eth_getUncleByBlockNumberAndIndex",
 		[]any{module.BlockNumberArg(number), hexutil.Uint(index)},
@@ -30,7 +30,7 @@ func UncleByBlockNumberAndIndex(number *big.Int, index uint) w3types.CallerFacto
 
 // UncleCountByBlockHash requests the number of uncles of the block with the
 // given hash.
-func UncleCountByBlockHash(hash common.Hash) w3types.CallerFactory[uint] {
+func UncleCountByBlockHash(hash common.Hash) w3types.RPCCallerFactory[uint] {
 	return module.NewFactory(
 		"eth_getUncleCountByBlockHash",
 		[]any{hash},
@@ -40,7 +40,7 @@ func UncleCountByBlockHash(hash common.Hash) w3types.CallerFactory[uint] {
 
 // UncleCountByBlockNumber requests the number of uncles of the block with the
 // given number.
-func UncleCountByBlockNumber(number *big.Int) w3types.CallerFactory[uint] {
+func UncleCountByBlockNumber(number *big.Int) w3types.RPCCallerFactory[uint] {
 	return module.NewFactory(
 		"eth_getUncleCountByBlockNumber",
 		[]any{module.BlockNumberArg(number)},

--- a/module/txpool/content.go
+++ b/module/txpool/content.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Content requests the pending and queued transactions in the transaction pool.
-func Content() w3types.CallerFactory[ContentResponse] {
+func Content() w3types.RPCCallerFactory[ContentResponse] {
 	return module.NewFactory[ContentResponse](
 		"txpool_content",
 		nil,
@@ -20,7 +20,7 @@ func Content() w3types.CallerFactory[ContentResponse] {
 
 // ContentFrom requests the pending and queued transactions in the transaction pool
 // from the given address.
-func ContentFrom(addr common.Address) w3types.CallerFactory[ContentFromResponse] {
+func ContentFrom(addr common.Address) w3types.RPCCallerFactory[ContentFromResponse] {
 	return module.NewFactory[ContentFromResponse](
 		"txpool_contentFrom",
 		[]any{addr},

--- a/module/txpool/status.go
+++ b/module/txpool/status.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Status requests the number of pending and queued transactions in the transaction pool.
-func Status() w3types.CallerFactory[StatusResponse] {
+func Status() w3types.RPCCallerFactory[StatusResponse] {
 	return module.NewFactory[StatusResponse](
 		"txpool_status",
 		nil,

--- a/module/web3/client_version.go
+++ b/module/web3/client_version.go
@@ -6,7 +6,7 @@ import (
 )
 
 // ClientVersion requests the endpoints client version.
-func ClientVersion() w3types.CallerFactory[string] {
+func ClientVersion() w3types.RPCCallerFactory[string] {
 	return module.NewFactory[string](
 		"web3_clientVersion",
 		nil,

--- a/rpctest/test_case.go
+++ b/rpctest/test_case.go
@@ -14,11 +14,11 @@ import (
 )
 
 type TestCase[T any] struct {
-	Golden  string                   // File name in local "testdata/" directory without ".golden" extension
-	Call    w3types.CallerFactory[T] // Call to test
-	GotRet  T                        // Actual return value of the call
-	WantRet T                        // Wanted return value of the call
-	WantErr error                    // Wanted error of the call
+	Golden  string                      // File name in local "testdata/" directory without ".golden" extension
+	Call    w3types.RPCCallerFactory[T] // Call to test
+	GotRet  T                           // Actual return value of the call
+	WantRet T                           // Wanted return value of the call
+	WantErr error                       // Wanted error of the call
 }
 
 func RunTestCases[T any](t *testing.T, tests []TestCase[T], opts ...cmp.Option) {

--- a/w3types/interfaces.go
+++ b/w3types/interfaces.go
@@ -19,24 +19,33 @@ type Func interface {
 	DecodeReturns(output []byte, returns ...any) (err error)
 }
 
-// RequestCreator is the interface that wraps the basic CreateRequest method.
-type RequestCreator interface {
+// RPCCaller is the interface that groups the basic CreateRequest and
+// HandleResponse methods.
+type RPCCaller interface {
+	// Create a new rpc.BatchElem for doing the RPC call.
 	CreateRequest() (elem rpc.BatchElem, err error)
+
+	// Handle the response from the rpc.BatchElem to handle its result.
+	HandleResponse(elem rpc.BatchElem) (err error)
 }
 
-// ResponseHandler is the interface that wraps the basic HandleResponse method.
-type ResponseHandler interface {
-	HandleResponse(elem rpc.BatchElem) (err error)
+// RPCCallerFactory is the interface that wraps the basic Returns method.
+type RPCCallerFactory[T any] interface {
+
+	// Returns given argument points to the variable in which to store the
+	// calls result.
+	Returns(*T) Caller
 }
 
 // Caller is the interface that groups the basic CreateRequest and
 // HandleResponse methods.
-type Caller interface {
-	RequestCreator
-	ResponseHandler
-}
+//
+// Deprecated: Use the [RPCCaller] interface instead.
+type Caller = RPCCaller
 
 // CallerFactory is the interface that wraps the basic Returns method.
+//
+// Deprecated: Use the [RPCCallerFactory] interface instead.
 type CallerFactory[T any] interface {
 
 	// Returns given argument points to the variable in which to store the

--- a/w3types/interfaces.go
+++ b/w3types/interfaces.go
@@ -34,7 +34,7 @@ type RPCCallerFactory[T any] interface {
 
 	// Returns given argument points to the variable in which to store the
 	// calls result.
-	Returns(*T) Caller
+	Returns(*T) RPCCaller
 }
 
 // Caller is the interface that groups the basic CreateRequest and

--- a/w3vm/fetcher.go
+++ b/w3vm/fetcher.go
@@ -215,7 +215,7 @@ func (f *rpcFetcher) fetchHeaderHash(blockNumber *big.Int) (common.Hash, error) 
 	return hashAny.(common.Hash), nil
 }
 
-func (f *rpcFetcher) call(calls ...w3types.Caller) error {
+func (f *rpcFetcher) call(calls ...w3types.RPCCaller) error {
 	return f.client.Call(calls...)
 }
 

--- a/w3vm/util.go
+++ b/w3vm/util.go
@@ -79,7 +79,7 @@ func zeroHashFunc(uint64) common.Hash {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // ethBalance is like [eth.Balance], but returns the balance as [uint256.Int].
-func ethBalance(addr common.Address, blockNumber *big.Int) w3types.CallerFactory[uint256.Int] {
+func ethBalance(addr common.Address, blockNumber *big.Int) w3types.RPCCallerFactory[uint256.Int] {
 	return module.NewFactory[uint256.Int](
 		"eth_getBalance",
 		[]any{addr, module.BlockNumberArg(blockNumber)},
@@ -88,7 +88,7 @@ func ethBalance(addr common.Address, blockNumber *big.Int) w3types.CallerFactory
 }
 
 // ethStorageAt is like [eth.StorageAt], but returns the storage value as [uint256.Int].
-func ethStorageAt(addr common.Address, slot uint256.Int, blockNumber *big.Int) w3types.CallerFactory[uint256.Int] {
+func ethStorageAt(addr common.Address, slot uint256.Int, blockNumber *big.Int) w3types.RPCCallerFactory[uint256.Int] {
 	return module.NewFactory[uint256.Int](
 		"eth_getStorageAt",
 		[]any{addr, hexutil.U256(slot), module.BlockNumberArg(blockNumber)},

--- a/w3vm/vm.go
+++ b/w3vm/vm.go
@@ -340,7 +340,7 @@ func (opt *options) Signer() types.Signer {
 func (opts *options) Init() error {
 	// set fetcher
 	if opts.fetcher == nil && opts.forkClient != nil {
-		var calls []w3types.Caller
+		var calls []w3types.RPCCaller
 
 		latest := opts.forkBlockNumber == nil
 		if latest {


### PR DESCRIPTION
The old interfaces `w3types.Caller` and `w3types.CallerFactory` remain, but are deprecated and will be dropped in a future release.

Only the interface names change, their methods remain unchanged.