### PR TITLE
fix: support semi-colon EOS in event signatures

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -60,6 +60,13 @@ func TestNewEvent(t *testing.T) {
 			},
 		},
 		{
+			Signature: "Transfer(address indexed _from, address indexed _to, uint256 _value);",
+			WantEvent: &w3.Event{
+				Signature: "Transfer(address,address,uint256)",
+				Topic0:    w3.H("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"),
+			},
+		},
+		{
 			Signature: "Approval(address,address,uint256)",
 			WantEvent: &w3.Event{
 				Signature: "Approval(address,address,uint256)",

--- a/internal/abi/lexer.go
+++ b/internal/abi/lexer.go
@@ -78,7 +78,7 @@ Start:
 		l.accept(id0)
 		l.acceptRun(id)
 		return &item{itemTypeID, l.token()}, nil
-	case eof:
+	case eof, ';':
 		return &item{itemTypeEOF, ""}, nil
 	default:
 		return nil, fmt.Errorf("unexpected character: %c", l.next())


### PR DESCRIPTION
* see #119