### PR TITLE
Changed `WithRateLimiter` `costFunc`-arg to include the methods of all calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,6 +149,10 @@ func (c *Client) rateLimit(ctx context.Context, batchElems []rpc.BatchElem) erro
 
 	// limit requests based on Compute Units (CUs)
 	var cost int
+	if len(batchElems) > 1 {
+		// include the cost of the batch request itself
+		cost += c.rlCostFunc("")
+	}
 	for _, batchElem := range batchElems {
 		cost += c.rlCostFunc(batchElem.Method)
 	}

--- a/client.go
+++ b/client.go
@@ -149,11 +149,10 @@ func (c *Client) rateLimit(ctx context.Context, batchElems []rpc.BatchElem) erro
 
 	// limit requests based on Compute Units (CUs)
 	methods := make([]string, len(batchElems))
-	for i := range batchElems {
-		methods[i] = batchElems[i].Method
+	for i, batchElem := range batchElems {
+		methods[i] = batchElem.Method
 	}
 	cost := c.rlCostFunc(methods)
-
 	return c.rl.WaitN(ctx, cost)
 }
 
@@ -194,9 +193,8 @@ type Option func(*Client)
 // WithRateLimiter sets the rate limiter for the client. Set the optional argument
 // costFunc to nil to limit the number of requests. Supply a costFunc to limit
 // the the number of requests based on individual RPC calls for advanced rate
-// limiting by Compute Units (CUs). Note that if len(methods) > 1, the calls
-// are sent in a single batch request, and costFunc should return the total cost
-// accordingly. If len(methods) == 1, the call is not sent as a batch.
+// limiting by e.g. Compute Units (CUs). Note that only if len(methods) > 1, the
+// calls are sent in a batch request.
 func WithRateLimiter(rl *rate.Limiter, costFunc func(methods []string) (cost int)) Option {
 	return func(c *Client) {
 		c.rl = rl

--- a/client_test.go
+++ b/client_test.go
@@ -373,3 +373,25 @@ func ExampleWithRateLimiter() {
 	)
 	defer client.Close()
 }
+
+func ExampleWithRateLimiter_costFunc() {
+	// Limit the client to 30 requests per second and allow bursts of up to
+	// 100 requests using a cost function. This permits the cost of the
+	// batch itself to also be considered.
+	client := w3.MustDial("https://rpc.ankr.com/eth",
+		w3.WithRateLimiter(rate.NewLimiter(rate.Every(time.Second/30), 100),
+			func(method string) int {
+				switch method {
+				case "eth_getBalance":
+					return 1
+				case "eth_getTransactionCount":
+					return 1
+				case "": // for batch requests, this is the cost of the batch itself
+					return 1
+				default:
+					return 10
+				}
+			},
+		))
+	defer client.Close()
+}

--- a/client_test.go
+++ b/client_test.go
@@ -375,25 +375,14 @@ func ExampleWithRateLimiter() {
 }
 
 func ExampleWithRateLimiter_costFunc() {
-	// Limit the client to 30 requests per second and allow bursts of up to
-	// 100 requests using a cost function. This permits the cost of the
-	// batch itself to also be considered.
+	// Limit the client to 30 calls per second and allow bursts of up to
+	// 100 calls using a cost function. Batch requests have an additional charge.
 	client := w3.MustDial("https://rpc.ankr.com/eth",
 		w3.WithRateLimiter(rate.NewLimiter(rate.Every(time.Second/30), 100),
-			func(methods []string) int {
-				cost := 0
+			func(methods []string) (cost int) {
+				cost = len(methods) // charge 1 CU per call
 				if len(methods) > 1 {
-					cost += 1 // for the batch itself
-				}
-				for _, method := range methods {
-					switch method {
-					case "eth_getBalance":
-						cost += 1
-					case "eth_getTransactionCount":
-						cost += 1
-					default:
-						cost += 10
-					}
+					cost += 1 // charge 1 CU extra for the batch itself
 				}
 				return cost
 			},


### PR DESCRIPTION
This allows the cost func to provide a cost for the batch itself in batch requests. Some providers (Infura) include this as part of their rate limiting.

Ref: https://docs.infura.io/api/networks/ethereum/how-to/make-batch-requests