### PR TITLE
Compatible with BSC GETH

### DIFF
--- a/w3vm/db.go
+++ b/w3vm/db.go
@@ -140,3 +140,6 @@ func (*db) Commit(collectLeaf bool) (common.Hash, *trienode.NodeSet, error) {
 func (*db) NodeIterator(startKey []byte) (trie.NodeIterator, error) { panic("not implemented") }
 
 func (*db) Prove(key []byte, proofDb ethdb.KeyValueWriter) error { panic("not implemented") }
+
+// NoTries returns whether the database has tries storage.
+func (*db) NoTries() bool { panic("not implemented") }

--- a/w3vm/multi_tracer.go
+++ b/w3vm/multi_tracer.go
@@ -89,3 +89,7 @@ func (m multiEVMLogger) CaptureFault(pc uint64, op vm.OpCode, gas, cost uint64, 
 		tracer.CaptureFault(pc, op, gas, cost, scope, depth, err)
 	}
 }
+
+func (m multiEVMLogger) CaptureSystemTxEnd(intrinsicGas uint64) {
+
+}


### PR DESCRIPTION
eg:
```
	vm, err := w3vm.New(
		w3vm.WithChainConfig(params.BSCChainConfig),
		w3vm.WithFork(client, nil),
		w3vm.WithNoBaseFee(),
		)

```